### PR TITLE
Fix possible NPE

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeFileSet.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/browser/TreeFileSet.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import org.openmicroscopy.shoola.agents.dataBrowser.DataBrowserAgent;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.Registry;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 //Third-party libraries
 
@@ -79,8 +80,12 @@ public class TreeFileSet
 		
 		switch (type) {
 			case MOVIE: return "Movies";
-			case ORPHANED_IMAGES: 
-			    return (String) reg.lookup(LookupNames.ORPHANED_IMAGE_NAME);
+			case ORPHANED_IMAGES:
+			    String v = (String) reg.lookup(LookupNames.ORPHANED_IMAGE_NAME);
+			    if (CommonsLangUtils.isNotBlank(v)) {
+			        return v;
+			    }
+			    return "Orphaned Images";
 			case TAG:
 				return "Tags used not owned";
 			case OTHER:


### PR DESCRIPTION
The problem was reported by @chris-allan when opening
insight against a local server w/o data for a given user.

NPE

```

java.lang.NullPointerException: No hierarchy object.
    at org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay.<init>(TreeImageDisplay.java:201)
    at org.openmicroscopy.shoola.agents.util.browser.TreeImageSet.<init>(TreeImageSet.java:105)
    at org.openmicroscopy.shoola.agents.util.browser.TreeFileSet.<init>(TreeFileSet.java:102)
    at org.openmicroscopy.shoola.agents.treeviewer.browser.BrowserUI.buildOrphanImagesNode(BrowserUI.java:1223)
    at org.openmicroscopy.shoola.agents.treeviewer.browser.BrowserUI.setExperimenterData(BrowserUI.java:1896)
    at org.openmicroscopy.shoola.agents.treeviewer.browser.BrowserComponent.setExperimenterData(BrowserComponent.java:1180)
    at org.openmicroscopy.shoola.agents.treeviewer.ExperimenterDataLoader.handleResult(ExperimenterDataLoader.java:240)
    at org.openmicroscopy.shoola.env.data.events.DSCallAdapter.eventFired(DSCallAdapter.java:90)
    at org.openmicroscopy.shoola.env.data.views.BatchCallMonitor$1.run(BatchCallMonitor.java:124)
```
