### PR TITLE
Additional Eclipse cleanup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -398,7 +398,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
     </target>
 
     <target name="test-dist" description="Copy test files into dist for further testing" depends="test-compile">
-        <ivy:resolve file="test.xml" type="jar" conf="test" settingsRef="ivy.toplevel" log="quiet"/>
+        <ivy:resolve file="test.xml" type="jar,bundle" conf="test" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="test" pattern="${dist.dir}/lib/client/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
     </target>
 

--- a/components/antlib/resources/global.xml
+++ b/components/antlib/resources/global.xml
@@ -495,14 +495,14 @@
         </macrodef>
 
         <macrodef name="tryEclipse">
-            <attribute name="settingsRef"/>
+            <attribute name="settingsRef" default="ivy.${ant.project.name}"/>
             <attribute name="filter" default="false"/>
             <sequential>
                 <trycatch>
                     <try>
                         <ivy:resolve file="test.xml" type="jar,bundle" conf="test" settingsRef="@{settingsRef}" log="quiet"/>
                         <taskdef name="ivyeclipse" classname="IVY1016.EclipseClasspath" loaderref="ivy.loader"/>
-                        <ivyeclipse conf="test" filter="@{filter}"/>
+                        <ivyeclipse conf="test" filter="@{filter}" settingsRef="@{settingsRef}"/>
                     </try>
                     <catch>
                         <echo>
@@ -514,7 +514,7 @@
                         </echo>
                         <ivy:resolve file="ivy.xml" type="jar,bundle" conf="build" settingsRef="@{settingsRef}" log="quiet"/>
                         <taskdef name="ivyeclipse" classname="IVY1016.EclipseClasspath" loaderref="ivy.loader"/>
-                        <ivyeclipse conf="build" filter="@{filter}"/>
+                        <ivyeclipse conf="build" filter="@{filter}" settingsRef="@{settingsRef}"/>
                     </catch>
                 </trycatch>
             </sequential>

--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -117,12 +117,6 @@ build_year = "${python_build_year}"
     </macrodef>
 
     <target name="python-install" unless="env.NOPYTHON">
-        <!-- The renaming which takes place here doesn't seem to work with eggs.
-        Rolling back to using the expanded directory
-        <installIvy/>
-        <ivy:resolve settingsRef="ivy.${ant.project.name}" file="${basedir}/ivy.xml" type="jar" log="quiet"/>
-        <publishArtifact pattern="dist/*.egg"/>
-        -->
         <copy todir="../target/lib/python">
             <fileset dir="${basedir}/build/lib" includes="**/*"/>
         </copy>


### PR DESCRIPTION
This should:
- fix the `DEPRECATED` warnings when running `build-eclipse`
- add the bundle type to another resolve target

Remaining locations where jar types are resolved are in components/antlib/resources/lifecycle.xml and components/insight/build/build.xml. Maybe we wait until conflicts arise while developing.
