### PR TITLE
Add full path for enumeration in javadoc

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/MapTaskPaneUI.java
@@ -330,9 +330,10 @@ public class MapTaskPaneUI extends AnnotationTaskPaneUI implements
      * Show only specific types of MapAnnotations
      * 
      * @param filter
-     *            One of: {@link Filter#SHOW_ALL}, see
-     *            {@link Filter#ADDED_BY_ME}, see
-     *            {@link Filter#ADDED_BY_OTHERS}
+     *            One of:
+     *            {@link org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter#SHOW_ALL},
+     *            {@link org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter#ADDED_BY_ME},
+     *            {@link org.openmicroscopy.shoola.agents.metadata.editor.AnnotationTaskPaneUI.Filter#ADDED_BY_OTHERS}
      */
     public void filter(Filter filter) {
         for (MapTable table : mapTables) {


### PR DESCRIPTION
Full path is required for inner class and enum.
